### PR TITLE
Adding more support delegates to control the show and dismiss of the menu

### DIFF
--- a/RNFrostedSidebar.h
+++ b/RNFrostedSidebar.h
@@ -7,7 +7,7 @@
 //
 //  Original Dribbble shot by Jakub Antalik
 //  http://dribbble.com/shots/1194205-Sidebar-calendar-animation
-//  
+//
 
 #import <UIKit/UIKit.h>
 
@@ -15,6 +15,10 @@
 
 @protocol RNFrostedSidebarDelegate <NSObject>
 @optional
+- (void)sidebar:(RNFrostedSidebar *)sidebar willShowOnScreenAnimated:(BOOL)animatedYesOrNo;
+- (void)sidebar:(RNFrostedSidebar *)sidebar didShowOnScreenAnimated:(BOOL)animatedYesOrNo;
+- (void)sidebar:(RNFrostedSidebar *)sidebar willDismissFromScreenAnimated:(BOOL)animatedYesOrNo;
+- (void)sidebar:(RNFrostedSidebar *)sidebar didDismissFromScreenAnimated:(BOOL)animatedYesOrNo;
 - (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index;
 - (void)sidebar:(RNFrostedSidebar *)sidebar didEnable:(BOOL)itemEnabled itemAtIndex:(NSUInteger)index;
 @end


### PR DESCRIPTION
There are situations where you sometimes need to modify itens on your UI on a way that is synchronized with the menu appearance and dismiss. Adding some more accurate delegates methods that fire on will/did show and on will/did dismiss.

Also a little bug correction for the not animated appearance of the menu (animation flag being ignored).
