### PR TITLE
Behave in navigationController

### DIFF
--- a/RNFrostedSidebar.h
+++ b/RNFrostedSidebar.h
@@ -75,6 +75,7 @@
 - (void)showInViewController:(UIViewController *)controller animated:(BOOL)animated;
 
 - (void)dismiss;
+- (void)dismissInNavigation;
 - (void)dismissAnimated:(BOOL)animated;
 
 @end

--- a/RNFrostedSidebar.m
+++ b/RNFrostedSidebar.m
@@ -475,6 +475,11 @@ static RNFrostedSidebar *rn_frostedMenu;
     [self dismissAnimated:YES];
 }
 
+- (void)dismissInNavigation {
+    [self removeFromParentViewController];
+    [self dismissAnimated:YES];
+}
+
 - (void)dismissAnimated:(BOOL)animated {
     void (^completion)(BOOL) = ^(BOOL finished){
         [self rn_removeFromParentViewControllerCallingAppearanceMethods:YES];


### PR DESCRIPTION
As a solution to the subject discussed in [Issue #8](https://github.com/rnystrom/RNFrostedSidebar/issues/8), where [RNFrostedSidebar](https://github.com/rnystrom/RNFrostedSidebar) is used to push a new viewController in a navigationController.

Show the sidebar on top of the navigationController:

```
    RNFrostedSidebar *callout = [[RNFrostedSidebar alloc] initWithImages:images];
    callout.delegate = self;
    [callout show];
```

In `didTapItemAtIndex` call `dismissInNavigation` before sergue to correctly remove the sidebar from the parentViewController before pushing the new viewController, and thereby keep the navigationBar.

```
- (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index {
    if (index == 0) {
        [sidebar dismissInNavigation];
        [self performSegueWithIdentifier:@"newSegue" sender:self];
    }
}
```

You could also just call `[self removeFromParentViewController]` every time in `dismissAnimated:(BOOL)animated`, but I think a dedicated call is more suited.

I think a lot of people is using your control with a navigationController. A test case of this scenario would be nice in [your](https://github.com/rnystrom) demo project, but that is up to you.
