### PR TITLE
Proposed solution to issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ callout.delegate = self;
 [callout show];
 ```
 
+If you use <code>RNFrostedSidebar</code> with a <code>UINavigationController</code>, you can push another <code>UIViewController</code> after selecting a button.
+Simply initialize it in <code>sidebar:didTapItemAtIndex:</code>, then push it onto the navigation stack after dimissing the sidebar with <code>-dismissAnimated:completion:</code>.
+
+```objc
+- (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index {
+    if (index == 1) {
+        [sidebar dismissAnimated:YES completion:^(BOOL finished) {
+            if (finished) {
+                UIViewController *secondVC = [[UIViewController alloc] init];
+                [self.navigationController pushViewController:secondVC animated:YES];
+            }
+        }];
+    }
+}
+```
+
 ## Customization
 
 I've exposed a healthy amount of options for you to customize the appearance and animation of the control.

--- a/RNFrostedSidebar.h
+++ b/RNFrostedSidebar.h
@@ -74,6 +74,8 @@
 - (void)showAnimated:(BOOL)animated;
 - (void)showInViewController:(UIViewController *)controller animated:(BOOL)animated;
 
-- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish;
+- (void)dismiss;
+- (void)dismissAnimated:(BOOL)animated;
+- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 
 @end

--- a/RNFrostedSidebar.h
+++ b/RNFrostedSidebar.h
@@ -76,5 +76,6 @@
 
 - (void)dismiss;
 - (void)dismissAnimated:(BOOL)animated;
+- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish;
 
 @end

--- a/RNFrostedSidebar.h
+++ b/RNFrostedSidebar.h
@@ -74,8 +74,6 @@
 - (void)showAnimated:(BOOL)animated;
 - (void)showInViewController:(UIViewController *)controller animated:(BOOL)animated;
 
-- (void)dismiss;
-- (void)dismissAnimated:(BOOL)animated;
 - (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish;
 
 @end

--- a/RNFrostedSidebar.m
+++ b/RNFrostedSidebar.m
@@ -380,8 +380,7 @@ static RNFrostedSidebar *rn_frostedMenu;
 
 - (void)showInViewController:(UIViewController *)controller animated:(BOOL)animated {
     if (rn_frostedMenu != nil) {
-        [rn_frostedMenu dismissAnimated:NO completion:^(BOOL status) {
-		}];
+        [rn_frostedMenu dismissAnimated:NO completion:nil];
     }
     
     if ([self.delegate respondsToSelector:@selector(sidebar:willShowOnScreenAnimated:)]) {
@@ -472,14 +471,24 @@ static RNFrostedSidebar *rn_frostedMenu;
 
 #pragma mark - Dismiss
 
-- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish {
-    void (^completion)(BOOL) = ^(BOOL finished){
+- (void)dismiss {
+    [self dismissAnimated:YES completion:nil];
+}
+
+- (void)dismissAnimated:(BOOL)animated {
+    [self dismissAnimated:animated completion:nil];
+}
+
+- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion {
+    void (^completionBlock)(BOOL) = ^(BOOL finished){
         [self rn_removeFromParentViewControllerCallingAppearanceMethods:YES];
         
         if ([self.delegate respondsToSelector:@selector(sidebar:didDismissFromScreenAnimated:)]) {
             [self.delegate sidebar:self didDismissFromScreenAnimated:YES];
         }
-		finish(finished);
+		if (completion) {
+			completion(finished);
+		}
     };
     
     if ([self.delegate respondsToSelector:@selector(sidebar:willDismissFromScreenAnimated:)]) {
@@ -502,10 +511,10 @@ static RNFrostedSidebar *rn_frostedMenu;
                              self.contentView.frame = contentFrame;
                              self.blurView.frame = blurFrame;
                          }
-                         completion:completion];
+                         completion:completionBlock];
     }
     else {
-        completion(YES);
+        completionBlock(YES);
     }
 }
 
@@ -514,8 +523,7 @@ static RNFrostedSidebar *rn_frostedMenu;
 - (void)handleTap:(UITapGestureRecognizer *)recognizer {
     CGPoint location = [recognizer locationInView:self.view];
     if (! CGRectContainsPoint(self.contentView.frame, location)) {
-        [self dismissAnimated:YES completion:^(BOOL status) {
-		}];
+        [self dismissAnimated:YES completion:nil];
     }
     else {
         NSInteger tapIndex = [self indexOfTap:[recognizer locationInView:self.contentView]];

--- a/RNFrostedSidebar.m
+++ b/RNFrostedSidebar.m
@@ -511,6 +511,43 @@ static RNFrostedSidebar *rn_frostedMenu;
     }
 }
 
+- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish {
+    void (^completion)(BOOL) = ^(BOOL finished){
+        [self rn_removeFromParentViewControllerCallingAppearanceMethods:YES];
+        
+        if ([self.delegate respondsToSelector:@selector(sidebar:didDismissFromScreenAnimated:)]) {
+            [self.delegate sidebar:self didDismissFromScreenAnimated:YES];
+        }
+		finish(finished);
+    };
+    
+    if ([self.delegate respondsToSelector:@selector(sidebar:willDismissFromScreenAnimated:)]) {
+        [self.delegate sidebar:self willDismissFromScreenAnimated:YES];
+    }
+    
+    if (animated) {
+        CGFloat parentWidth = self.view.bounds.size.width;
+        CGRect contentFrame = self.contentView.frame;
+        contentFrame.origin.x = self.showFromRight ? parentWidth : -_width;
+        
+        CGRect blurFrame = self.blurView.frame;
+        blurFrame.origin.x = self.showFromRight ? parentWidth : 0;
+        blurFrame.size.width = 0;
+        
+        [UIView animateWithDuration:self.animationDuration
+                              delay:0
+                            options:UIViewAnimationOptionBeginFromCurrentState
+                         animations:^{
+                             self.contentView.frame = contentFrame;
+                             self.blurView.frame = blurFrame;
+                         }
+                         completion:completion];
+    }
+    else {
+        completion(YES);
+    }
+}
+
 #pragma mark - Gestures
 
 - (void)handleTap:(UITapGestureRecognizer *)recognizer {

--- a/RNFrostedSidebar.m
+++ b/RNFrostedSidebar.m
@@ -380,7 +380,8 @@ static RNFrostedSidebar *rn_frostedMenu;
 
 - (void)showInViewController:(UIViewController *)controller animated:(BOOL)animated {
     if (rn_frostedMenu != nil) {
-        [rn_frostedMenu dismissAnimated:NO];
+        [rn_frostedMenu dismissAnimated:NO completion:^(BOOL status) {
+		}];
     }
     
     if ([self.delegate respondsToSelector:@selector(sidebar:willShowOnScreenAnimated:)]) {
@@ -471,46 +472,6 @@ static RNFrostedSidebar *rn_frostedMenu;
 
 #pragma mark - Dismiss
 
-- (void)dismiss {
-    [self dismissAnimated:YES];
-}
-
-- (void)dismissAnimated:(BOOL)animated {
-    void (^completion)(BOOL) = ^(BOOL finished){
-        [self rn_removeFromParentViewControllerCallingAppearanceMethods:YES];
-        
-        if ([self.delegate respondsToSelector:@selector(sidebar:didDismissFromScreenAnimated:)]) {
-            [self.delegate sidebar:self didDismissFromScreenAnimated:YES];
-        }
-    };
-    
-    if ([self.delegate respondsToSelector:@selector(sidebar:willDismissFromScreenAnimated:)]) {
-        [self.delegate sidebar:self willDismissFromScreenAnimated:YES];
-    }
-    
-    if (animated) {
-        CGFloat parentWidth = self.view.bounds.size.width;
-        CGRect contentFrame = self.contentView.frame;
-        contentFrame.origin.x = self.showFromRight ? parentWidth : -_width;
-        
-        CGRect blurFrame = self.blurView.frame;
-        blurFrame.origin.x = self.showFromRight ? parentWidth : 0;
-        blurFrame.size.width = 0;
-        
-        [UIView animateWithDuration:self.animationDuration
-                              delay:0
-                            options:UIViewAnimationOptionBeginFromCurrentState
-                         animations:^{
-                             self.contentView.frame = contentFrame;
-                             self.blurView.frame = blurFrame;
-                         }
-                         completion:completion];
-    }
-    else {
-        completion(YES);
-    }
-}
-
 - (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish {
     void (^completion)(BOOL) = ^(BOOL finished){
         [self rn_removeFromParentViewControllerCallingAppearanceMethods:YES];
@@ -553,7 +514,8 @@ static RNFrostedSidebar *rn_frostedMenu;
 - (void)handleTap:(UITapGestureRecognizer *)recognizer {
     CGPoint location = [recognizer locationInView:self.view];
     if (! CGRectContainsPoint(self.contentView.frame, location)) {
-        [self dismissAnimated:YES];
+        [self dismissAnimated:YES completion:^(BOOL status) {
+		}];
     }
     else {
         NSInteger tapIndex = [self indexOfTap:[recognizer locationInView:self.contentView]];

--- a/example/ViewController.m
+++ b/example/ViewController.m
@@ -62,7 +62,9 @@
 - (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index {
     NSLog(@"Tapped item at index %i",index);
     if (index == 3) {
-        [sidebar dismiss];
+        [sidebar dismissAnimated:YES completion:^(BOOL status) {
+		}];
+		[sidebar dismissViewControllerAnimated:<#(BOOL)#> completion:<#^(void)completion#>];
     }
 }
 

--- a/example/ViewController.m
+++ b/example/ViewController.m
@@ -62,9 +62,7 @@
 - (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index {
     NSLog(@"Tapped item at index %i",index);
     if (index == 3) {
-        [sidebar dismissAnimated:YES completion:^(BOOL status) {
-		}];
-		[sidebar dismissViewControllerAnimated:<#(BOOL)#> completion:<#^(void)completion#>];
+        [sidebar dismissAnimated:YES completion:nil];
     }
 }
 


### PR DESCRIPTION
This is my proposed solution to issue #8 (In ios 7 if i try to push a ViewController from your code it doesn't pass the Navigationbar but in iOS 6 it does.).

I only add a completion block to `- (void)dismissAnimated:(BOOL)animated`

We normally show the sidebar on our navigation controller:

```
RNFrostedSidebar *callout = [[RNFrostedSidebar alloc] initWithImages:images];
    callout.delegate = self;
    [callout show];
```

Then dismiss it using `- (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL status))finish;`:

```
- (void)sidebar:(RNFrostedSidebar *)sidebar didTapItemAtIndex:(NSUInteger)index {
    [sidebar dismissAnimated:YES completion:^(BOOL status) {
        if (status) {
            [self.navigationController pushViewController:myNewVC animated:YES];
        }
    }];
}
```

The advantage compare to the previous proposed solution is that you doesn't need to hide the navigation bar while the sidebar is shown. 
