### PR TITLE
Updated to use Carthage and increase deployment target to iOS 9

### DIFF
--- a/RNFrostedSidebar.m
+++ b/RNFrostedSidebar.m
@@ -329,7 +329,7 @@ static RNFrostedSidebar *rn_frostedMenu;
     return YES;
 }
 
-- (NSUInteger)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAll;
 }
 

--- a/RNFrostedSidebar.xcodeproj/project.pbxproj
+++ b/RNFrostedSidebar.xcodeproj/project.pbxproj
@@ -34,7 +34,36 @@
 		8681BB5917BAFB5A007F1B43 /* RNFrostedSidebar.m in Sources */ = {isa = PBXBuildFile; fileRef = 8681BB5817BAFB5A007F1B43 /* RNFrostedSidebar.m */; };
 		86D2CBF917CEAFE50098397C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 862D1B2317BC2C9B00157004 /* QuartzCore.framework */; };
 		86D2CBFA17CEAFE90098397C /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 862D1B2517BC2CA000157004 /* Accelerate.framework */; };
+		E0820C3B1C4E7F5E004F5507 /* RNFrostedSidebarFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = E0820C3A1C4E7F5E004F5507 /* RNFrostedSidebarFramework.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E0820C3F1C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0820C381C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework */; };
+		E0820C401C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E0820C381C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E0820C451C4E7F68004F5507 /* RNFrostedSidebar.m in Sources */ = {isa = PBXBuildFile; fileRef = 8681BB5817BAFB5A007F1B43 /* RNFrostedSidebar.m */; };
+		E0820C461C4E7F73004F5507 /* RNFrostedSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 8681BB5717BAFB5A007F1B43 /* RNFrostedSidebar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E0820C3D1C4E7F5E004F5507 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8646015517BAF99800FCE7F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E0820C371C4E7F5E004F5507;
+			remoteInfo = RNFrostedSidebarFramework;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E0820C441C4E7F5E004F5507 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E0820C401C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		86251D3A17C3DE9E00837EBD /* burger.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = burger.png; sourceTree = "<group>"; };
@@ -71,6 +100,9 @@
 		8646017917BAF99800FCE7F4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		8681BB5717BAFB5A007F1B43 /* RNFrostedSidebar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNFrostedSidebar.h; sourceTree = "<group>"; };
 		8681BB5817BAFB5A007F1B43 /* RNFrostedSidebar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNFrostedSidebar.m; sourceTree = "<group>"; };
+		E0820C381C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNFrostedSidebarFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0820C3A1C4E7F5E004F5507 /* RNFrostedSidebarFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFrostedSidebarFramework.h; sourceTree = "<group>"; };
+		E0820C3C1C4E7F5E004F5507 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,11 +110,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0820C3F1C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework in Frameworks */,
 				86D2CBFA17CEAFE90098397C /* Accelerate.framework in Frameworks */,
 				86D2CBF917CEAFE50098397C /* QuartzCore.framework in Frameworks */,
 				8646016317BAF99800FCE7F4 /* CoreGraphics.framework in Frameworks */,
 				8646016517BAF99800FCE7F4 /* UIKit.framework in Frameworks */,
 				8646016117BAF99800FCE7F4 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E0820C341C4E7F5E004F5507 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +165,7 @@
 			isa = PBXGroup;
 			children = (
 				86251D3917C3DE9E00837EBD /* example */,
+				E0820C391C4E7F5E004F5507 /* RNFrostedSidebarFramework */,
 				8646015F17BAF99800FCE7F4 /* Frameworks */,
 				8646015E17BAF99800FCE7F4 /* Products */,
 				8681BB5717BAFB5A007F1B43 /* RNFrostedSidebar.h */,
@@ -136,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				8646015D17BAF99800FCE7F4 /* RNFrostedSidebar.app */,
+				E0820C381C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -153,7 +195,28 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E0820C391C4E7F5E004F5507 /* RNFrostedSidebarFramework */ = {
+			isa = PBXGroup;
+			children = (
+				E0820C3A1C4E7F5E004F5507 /* RNFrostedSidebarFramework.h */,
+				E0820C3C1C4E7F5E004F5507 /* Info.plist */,
+			);
+			path = RNFrostedSidebarFramework;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		E0820C351C4E7F5E004F5507 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0820C461C4E7F73004F5507 /* RNFrostedSidebar.h in Headers */,
+				E0820C3B1C4E7F5E004F5507 /* RNFrostedSidebarFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		8646015C17BAF99800FCE7F4 /* RNFrostedSidebar */ = {
@@ -163,15 +226,35 @@
 				8646015917BAF99800FCE7F4 /* Sources */,
 				8646015A17BAF99800FCE7F4 /* Frameworks */,
 				8646015B17BAF99800FCE7F4 /* Resources */,
+				E0820C441C4E7F5E004F5507 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				E0820C3E1C4E7F5E004F5507 /* PBXTargetDependency */,
 			);
 			name = RNFrostedSidebar;
 			productName = RNSideCallout;
 			productReference = 8646015D17BAF99800FCE7F4 /* RNFrostedSidebar.app */;
 			productType = "com.apple.product-type.application";
+		};
+		E0820C371C4E7F5E004F5507 /* RNFrostedSidebarFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E0820C411C4E7F5E004F5507 /* Build configuration list for PBXNativeTarget "RNFrostedSidebarFramework" */;
+			buildPhases = (
+				E0820C331C4E7F5E004F5507 /* Sources */,
+				E0820C341C4E7F5E004F5507 /* Frameworks */,
+				E0820C351C4E7F5E004F5507 /* Headers */,
+				E0820C361C4E7F5E004F5507 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNFrostedSidebarFramework;
+			productName = RNFrostedSidebarFramework;
+			productReference = E0820C381C4E7F5E004F5507 /* RNFrostedSidebarFramework.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -180,8 +263,13 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = RN;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Ryan Nystrom";
+				TargetAttributes = {
+					E0820C371C4E7F5E004F5507 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
 			};
 			buildConfigurationList = 8646015817BAF99800FCE7F4 /* Build configuration list for PBXProject "RNFrostedSidebar" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -196,6 +284,7 @@
 			projectRoot = "";
 			targets = (
 				8646015C17BAF99800FCE7F4 /* RNFrostedSidebar */,
+				E0820C371C4E7F5E004F5507 /* RNFrostedSidebarFramework */,
 			);
 		};
 /* End PBXProject section */
@@ -226,6 +315,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E0820C361C4E7F5E004F5507 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -240,7 +336,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E0820C331C4E7F5E004F5507 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0820C451C4E7F68004F5507 /* RNFrostedSidebar.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E0820C3E1C4E7F5E004F5507 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E0820C371C4E7F5E004F5507 /* RNFrostedSidebarFramework */;
+			targetProxy = E0820C3D1C4E7F5E004F5507 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		86251D3F17C3DE9E00837EBD /* InfoPlist.strings */ = {
@@ -272,6 +384,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -285,7 +398,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -317,7 +430,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -332,7 +445,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "example/RNFrostedSidebar-Prefix.pch";
 				INFOPLIST_FILE = "example/RNFrostedSidebar-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Ryan-Nystrom.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = RNFrostedSidebar;
 				WRAPPER_EXTENSION = app;
 			};
@@ -346,9 +461,67 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "example/RNFrostedSidebar-Prefix.pch";
 				INFOPLIST_FILE = "example/RNFrostedSidebar-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Ryan-Nystrom.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = RNFrostedSidebar;
 				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		E0820C421C4E7F5E004F5507 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = RNFrostedSidebarFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sales-i.RNFrostedSidebarFramework";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E0820C431C4E7F5E004F5507 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = RNFrostedSidebarFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sales-i.RNFrostedSidebarFramework";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -372,6 +545,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E0820C411C4E7F5E004F5507 /* Build configuration list for PBXNativeTarget "RNFrostedSidebarFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0820C421C4E7F5E004F5507 /* Debug */,
+				E0820C431C4E7F5E004F5507 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/RNFrostedSidebar.xcodeproj/project.pbxproj
+++ b/RNFrostedSidebar.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -430,7 +430,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -486,7 +486,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = RNFrostedSidebarFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sales-i.RNFrostedSidebarFramework";
@@ -514,7 +514,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = RNFrostedSidebarFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sales-i.RNFrostedSidebarFramework";
@@ -553,6 +553,7 @@
 				E0820C431C4E7F5E004F5507 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/RNFrostedSidebar.xcodeproj/xcshareddata/xcschemes/RNFrostedSidebarFramework.xcscheme
+++ b/RNFrostedSidebar.xcodeproj/xcshareddata/xcschemes/RNFrostedSidebarFramework.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E0820C371C4E7F5E004F5507"
+               BuildableName = "RNFrostedSidebarFramework.framework"
+               BlueprintName = "RNFrostedSidebarFramework"
+               ReferencedContainer = "container:RNFrostedSidebar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E0820C371C4E7F5E004F5507"
+            BuildableName = "RNFrostedSidebarFramework.framework"
+            BlueprintName = "RNFrostedSidebarFramework"
+            ReferencedContainer = "container:RNFrostedSidebar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E0820C371C4E7F5E004F5507"
+            BuildableName = "RNFrostedSidebarFramework.framework"
+            BlueprintName = "RNFrostedSidebarFramework"
+            ReferencedContainer = "container:RNFrostedSidebar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RNFrostedSidebarFramework/Info.plist
+++ b/RNFrostedSidebarFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/RNFrostedSidebarFramework/RNFrostedSidebarFramework.h
+++ b/RNFrostedSidebarFramework/RNFrostedSidebarFramework.h
@@ -1,0 +1,19 @@
+//
+//  RNFrostedSidebarFramework.h
+//  RNFrostedSidebarFramework
+//
+//  Created by Dillon Hoa on 19/01/2016.
+//  Copyright © 2016 Ryan Nystrom. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for RNFrostedSidebarFramework.
+FOUNDATION_EXPORT double RNFrostedSidebarFrameworkVersionNumber;
+
+//! Project version string for RNFrostedSidebarFramework.
+FOUNDATION_EXPORT const unsigned char RNFrostedSidebarFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <RNFrostedSidebarFramework/PublicHeader.h>
+
+

--- a/example/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/example/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -16,6 +26,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
       "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
@@ -43,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/example/RNFrostedSidebar-Info.plist
+++ b/example/RNFrostedSidebar-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>Ryan-Nystrom.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Why:
*updated the project to allow Carthage to build
*bumped the deployment target to iOS 9

This change addresses the need by:
*adding new framework target and referencing the RNFrostedSidebar.h
*sharing the framework scheme so Carthage can build
*updated project files to iOS 9 as per Xcode 7 standard
